### PR TITLE
Fix warning when using whenVisible in non ssr environment

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,7 +93,7 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
           });
         });
       }
-      if (io.current) {
+      if (io.current && childRef.current.childElementCount !== 0) {
         // As root node does not have any box model, it cannot intersect.
         io.current.observe(childRef.current.children[0]);
         cleanupFns.current.push(() => {


### PR DESCRIPTION
When running in development mode (non-ssr), with the `whenVisible` option, there will be the following error:
```
TypeError: Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'.
```
