### PR TITLE
split into smaller components

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,13 @@ import * as React from "react";
 
 import { isBrowser, isDev } from "./constants.macro";
 
+import { warnAboutDeprecation } from "./utils";
+
+export * from "./onEvents";
+export * from "./ssrOnly";
+export * from "./whenIdle";
+export * from "./whenVisible";
+
 export type LazyProps = {
   ssrOnly?: boolean;
   whenIdle?: boolean;
@@ -57,6 +64,11 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
     if (!childRef.current.hasChildNodes()) {
       setHydrated(true);
     }
+  }, []);
+
+  React.useEffect(() => {
+    warnAboutDeprecation({ on, ssrOnly, whenIdle, whenVisible });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import { isBrowser, isDev } from "./constants.macro";
-
 import { warnAboutDeprecation } from "./utils";
 
 export * from "./onEvents";
@@ -67,11 +66,9 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
   }, []);
 
   React.useEffect(() => {
-    warnAboutDeprecation({ on, ssrOnly, whenIdle, whenVisible });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  React.useEffect(() => {
+    if (isDev) {
+      warnAboutDeprecation({ on, ssrOnly, whenIdle, whenVisible });
+    }
     if (ssrOnly || hydrated) return;
     const cleanupFns: VoidFunction[] = [];
     function cleanup() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ const event = "hydrate";
 
 const io =
   isBrowser && IntersectionObserver
-    ? new IntersectionObserver(
+    ? /*#__PURE__*/ new IntersectionObserver(
         entries => {
           entries.forEach(entry => {
             if (entry.isIntersecting || entry.intersectionRatio > 0) {

--- a/src/onEvents.tsx
+++ b/src/onEvents.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { defaultStyle, useHydrationState } from "./utils";
+
+type Props = Omit<
+  React.HTMLProps<HTMLDivElement>,
+  "dangerouslySetInnerHTML"
+> & { on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap };
+
+function HydrateOn({ children, on, ...rest }: Props) {
+  const [childRef, hydrated, hydrate] = useHydrationState();
+
+  React.useEffect(() => {
+    if (hydrated) return;
+
+    const cleanupFns: VoidFunction[] = [];
+
+    function cleanup() {
+      for (let i = 0; i < cleanupFns.length; i++) {
+        cleanupFns[i]();
+      }
+    }
+
+    let events = Array.isArray(on) ? on.slice() : [on];
+
+    events.forEach(event => {
+      childRef.current.addEventListener(event, hydrate, {
+        once: true,
+        capture: true,
+        passive: true
+      });
+      cleanupFns.push(() => {
+        childRef.current.removeEventListener(event, hydrate, { capture: true });
+      });
+    });
+
+    return cleanup;
+  }, [hydrated, hydrate, on, childRef]);
+
+  if (hydrated) {
+    return (
+      <div ref={childRef} style={defaultStyle} children={children} {...rest} />
+    );
+  } else {
+    return (
+      <div
+        ref={childRef}
+        style={defaultStyle}
+        suppressHydrationWarning
+        {...rest}
+        dangerouslySetInnerHTML={{ __html: "" }}
+      />
+    );
+  }
+}
+
+export { HydrateOn };

--- a/src/onEvents.tsx
+++ b/src/onEvents.tsx
@@ -23,14 +23,16 @@ function HydrateOn({ children, on, ...rest }: Props) {
 
     let events = Array.isArray(on) ? on.slice() : [on];
 
+    const domElement = childRef.current!;
+
     events.forEach(event => {
-      childRef.current.addEventListener(event, hydrate, {
+      domElement.addEventListener(event, hydrate, {
         once: true,
         capture: true,
         passive: true
       });
       cleanupFns.push(() => {
-        childRef.current.removeEventListener(event, hydrate, { capture: true });
+        domElement.removeEventListener(event, hydrate, { capture: true });
       });
     });
 

--- a/src/onEvents.tsx
+++ b/src/onEvents.tsx
@@ -5,7 +5,7 @@ import { defaultStyle, useHydrationState } from "./utils";
 type Props = Omit<
   React.HTMLProps<HTMLDivElement>,
   "dangerouslySetInnerHTML"
-> & { on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap };
+> & { on: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap };
 
 function HydrateOn({ children, on, ...rest }: Props) {
   const [childRef, hydrated, hydrate] = useHydrationState();

--- a/src/ssrOnly.tsx
+++ b/src/ssrOnly.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import { defaultStyle, useHydrationState } from "./utils";
+
+type Props = Omit<React.HTMLProps<HTMLDivElement>, "dangerouslySetInnerHTML">;
+
+function SsrOnly({ children, ...rest }: Props) {
+  const [childRef, hydrated] = useHydrationState();
+
+  if (hydrated) {
+    return (
+      <div ref={childRef} style={defaultStyle} children={children} {...rest} />
+    );
+  } else {
+    return (
+      <div
+        ref={childRef}
+        style={defaultStyle}
+        suppressHydrationWarning
+        {...rest}
+        dangerouslySetInnerHTML={{ __html: "" }}
+      />
+    );
+  }
+}
+
+export { SsrOnly };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,96 @@
+import * as React from "react";
+
+import { isBrowser, isDev } from "./constants.macro";
+
+// React currently throws a warning when using useLayoutEffect on the server.
+const useIsomorphicLayoutEffect = isBrowser
+  ? React.useLayoutEffect
+  : React.useEffect;
+
+function useHydrationState(): [
+  React.MutableRefObject<HTMLDivElement>,
+  boolean,
+  VoidFunction
+] {
+  const childRef = React.useRef<HTMLDivElement>(null);
+
+  const [hydrated, setHydrated] = React.useState(!isBrowser);
+
+  useIsomorphicLayoutEffect(() => {
+    // No SSR Content
+    if (!childRef.current.hasChildNodes()) {
+      setHydrated(true);
+    }
+  }, []);
+
+  const hydrate = React.useCallback(() => {
+    setHydrated(true);
+  }, []);
+
+  return React.useMemo(() => [childRef, hydrated, hydrate], [
+    hydrated,
+    hydrate
+  ]);
+}
+
+const defaultStyle: React.CSSProperties = { display: "contents" };
+
+function warnAboutDeprecation({ on, whenIdle, whenVisible, ssrOnly }) {
+  if (isDev) {
+    console.warn(
+      "[%creact-lazy-hydration%c]: Default export is deprecated",
+      "font-weight:bold",
+      ""
+    );
+    if (on != null) {
+      console.warn(
+        `To hydrate on events, use the new HydrateOn component
+      %cimport { HydrateOn } from "react-lazy-hydration";
+
+      <HydrateOn on={${JSON.stringify(on)}}>
+       {children}
+      </HydrateOn>
+      `,
+        "color:red"
+      );
+    }
+    if (whenIdle != null) {
+      console.warn(
+        `To hydrate on idle, use the new HydrateOnIdle component
+      %cimport { HydrateOnIdle } from "react-lazy-hydration";
+
+      <HydrateOnIdle>
+       {children}
+      </HydrateOnIdle>
+      `,
+        "color:red"
+      );
+    }
+    if (whenVisible != null) {
+      console.warn(
+        `To hydrate when component becomes visible, use the new HydrateWhenVisible component
+      %cimport { HydrateWhenVisible } from "react-lazy-hydration";
+
+      <HydrateWhenVisible>
+       {children}
+      </HydrateWhenVisible>
+      `,
+        "color:red"
+      );
+    }
+    if (ssrOnly != null) {
+      console.warn(
+        `To skip client side hydration, use the new SsrOnly component
+      %cimport { SsrOnly } from "react-lazy-hydration";
+
+      <SsrOnly>
+       {children}
+      </SsrOnly>
+      `,
+        "color:red"
+      );
+    }
+  }
+}
+
+export { useHydrationState, defaultStyle, warnAboutDeprecation };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ const useIsomorphicLayoutEffect = isBrowser
   : React.useEffect;
 
 function useHydrationState(): [
-  React.MutableRefObject<HTMLDivElement>,
+  React.MutableRefObject<HTMLDivElement | null>,
   boolean,
   VoidFunction
 ] {
@@ -18,7 +18,7 @@ function useHydrationState(): [
 
   useIsomorphicLayoutEffect(() => {
     // No SSR Content
-    if (!childRef.current.hasChildNodes()) {
+    if (!childRef.current!.hasChildNodes()) {
       setHydrated(true);
     }
   }, []);
@@ -27,15 +27,22 @@ function useHydrationState(): [
     setHydrated(true);
   }, []);
 
-  return React.useMemo(() => [childRef, hydrated, hydrate], [
-    hydrated,
-    hydrate
-  ]);
+  return [childRef, hydrated, hydrate];
 }
 
 const defaultStyle: React.CSSProperties = { display: "contents" };
 
-function warnAboutDeprecation({ on, whenIdle, whenVisible, ssrOnly }) {
+function warnAboutDeprecation({
+  on,
+  whenIdle,
+  whenVisible,
+  ssrOnly
+}: {
+  on?: string | string[];
+  whenIdle?: boolean;
+  whenVisible?: boolean;
+  ssrOnly?: boolean;
+}) {
   console.warn(
     "[%creact-lazy-hydration%c]: Default export is deprecated",
     "font-weight:bold",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { isBrowser, isDev } from "./constants.macro";
+import { isBrowser } from "./constants.macro";
 
 // React currently throws a warning when using useLayoutEffect on the server.
 const useIsomorphicLayoutEffect = isBrowser
@@ -36,60 +36,58 @@ function useHydrationState(): [
 const defaultStyle: React.CSSProperties = { display: "contents" };
 
 function warnAboutDeprecation({ on, whenIdle, whenVisible, ssrOnly }) {
-  if (isDev) {
+  console.warn(
+    "[%creact-lazy-hydration%c]: Default export is deprecated",
+    "font-weight:bold",
+    ""
+  );
+  if (on != null) {
     console.warn(
-      "[%creact-lazy-hydration%c]: Default export is deprecated",
-      "font-weight:bold",
-      ""
-    );
-    if (on != null) {
-      console.warn(
-        `To hydrate on events, use the new HydrateOn component
+      `To hydrate on events, use the new HydrateOn component
       %cimport { HydrateOn } from "react-lazy-hydration";
 
       <HydrateOn on={${JSON.stringify(on)}}>
        {children}
       </HydrateOn>
       `,
-        "color:red"
-      );
-    }
-    if (whenIdle != null) {
-      console.warn(
-        `To hydrate on idle, use the new HydrateOnIdle component
+      "color:red"
+    );
+  }
+  if (whenIdle != null) {
+    console.warn(
+      `To hydrate on idle, use the new HydrateOnIdle component
       %cimport { HydrateOnIdle } from "react-lazy-hydration";
 
       <HydrateOnIdle>
        {children}
       </HydrateOnIdle>
       `,
-        "color:red"
-      );
-    }
-    if (whenVisible != null) {
-      console.warn(
-        `To hydrate when component becomes visible, use the new HydrateWhenVisible component
+      "color:red"
+    );
+  }
+  if (whenVisible != null) {
+    console.warn(
+      `To hydrate when component becomes visible, use the new HydrateWhenVisible component
       %cimport { HydrateWhenVisible } from "react-lazy-hydration";
 
       <HydrateWhenVisible>
        {children}
       </HydrateWhenVisible>
       `,
-        "color:red"
-      );
-    }
-    if (ssrOnly != null) {
-      console.warn(
-        `To skip client side hydration, use the new SsrOnly component
+      "color:red"
+    );
+  }
+  if (ssrOnly != null) {
+    console.warn(
+      `To skip client side hydration, use the new SsrOnly component
       %cimport { SsrOnly } from "react-lazy-hydration";
 
       <SsrOnly>
        {children}
       </SsrOnly>
       `,
-        "color:red"
-      );
-    }
+      "color:red"
+    );
   }
 }
 

--- a/src/whenIdle.tsx
+++ b/src/whenIdle.tsx
@@ -10,30 +10,20 @@ function HydrateOnIdle({ children, ...rest }: Props) {
   React.useEffect(() => {
     if (hydrated) return;
 
-    const cleanupFns: VoidFunction[] = [];
-
-    function cleanup() {
-      for (let i = 0; i < cleanupFns.length; i++) {
-        cleanupFns[i]();
-      }
-    }
-
     // @ts-ignore
     if (requestIdleCallback) {
       // @ts-ignore
       const idleCallbackId = requestIdleCallback(hydrate, { timeout: 500 });
-      cleanupFns.push(() => {
+      return () => {
         // @ts-ignore
         cancelIdleCallback(idleCallbackId);
-      });
+      };
     } else {
       const id = setTimeout(hydrate, 2000);
-      cleanupFns.push(() => {
+      return () => {
         clearTimeout(id);
-      });
+      };
     }
-
-    return cleanup;
   }, [hydrated, hydrate]);
 
   if (hydrated) {

--- a/src/whenIdle.tsx
+++ b/src/whenIdle.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+
+import { defaultStyle, useHydrationState } from "./utils";
+
+type Props = Omit<React.HTMLProps<HTMLDivElement>, "dangerouslySetInnerHTML">;
+
+function HydrateOnIdle({ children, ...rest }: Props) {
+  const [childRef, hydrated, hydrate] = useHydrationState();
+
+  React.useEffect(() => {
+    if (hydrated) return;
+
+    const cleanupFns: VoidFunction[] = [];
+
+    function cleanup() {
+      for (let i = 0; i < cleanupFns.length; i++) {
+        cleanupFns[i]();
+      }
+    }
+
+    // @ts-ignore
+    if (requestIdleCallback) {
+      // @ts-ignore
+      const idleCallbackId = requestIdleCallback(hydrate, { timeout: 500 });
+      cleanupFns.push(() => {
+        // @ts-ignore
+        cancelIdleCallback(idleCallbackId);
+      });
+    } else {
+      const id = setTimeout(hydrate, 2000);
+      cleanupFns.push(() => {
+        clearTimeout(id);
+      });
+    }
+
+    return cleanup;
+  }, [hydrated, hydrate]);
+
+  if (hydrated) {
+    return (
+      <div ref={childRef} style={defaultStyle} children={children} {...rest} />
+    );
+  } else {
+    return (
+      <div
+        ref={childRef}
+        style={defaultStyle}
+        suppressHydrationWarning
+        {...rest}
+        dangerouslySetInnerHTML={{ __html: "" }}
+      />
+    );
+  }
+}
+
+export { HydrateOnIdle };

--- a/src/whenVisible.tsx
+++ b/src/whenVisible.tsx
@@ -15,14 +15,6 @@ function HydrateWhenVisible({ children, observerOptions, ...rest }: Props) {
   React.useEffect(() => {
     if (hydrated) return;
 
-    const cleanupFns: VoidFunction[] = [];
-
-    function cleanup() {
-      for (let i = 0; i < cleanupFns.length; i++) {
-        cleanupFns[i]();
-      }
-    }
-
     const io = IntersectionObserver
       ? new IntersectionObserver(entries => {
           // As only one element is observed,
@@ -41,11 +33,9 @@ function HydrateWhenVisible({ children, observerOptions, ...rest }: Props) {
       const el = childRef.current.children[0];
       io.observe(el);
 
-      cleanupFns.push(() => {
+      return () => {
         io.unobserve(el);
-      });
-
-      return cleanup;
+      };
     } else {
       hydrate();
     }

--- a/src/whenVisible.tsx
+++ b/src/whenVisible.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+import { defaultStyle, useHydrationState } from "./utils";
+
+type Props = Omit<
+  React.HTMLProps<HTMLDivElement>,
+  "dangerouslySetInnerHTML"
+> & {
+  observerOptions?: IntersectionObserverInit;
+};
+
+function HydrateWhenVisible({ children, observerOptions, ...rest }: Props) {
+  const [childRef, hydrated, hydrate] = useHydrationState();
+
+  React.useEffect(() => {
+    if (hydrated) return;
+
+    const cleanupFns: VoidFunction[] = [];
+
+    function cleanup() {
+      for (let i = 0; i < cleanupFns.length; i++) {
+        cleanupFns[i]();
+      }
+    }
+
+    const io = IntersectionObserver
+      ? new IntersectionObserver(entries => {
+          // As only one element is observed,
+          // there is no need to loop over the array
+          if (entries.length) {
+            const entry = entries[0];
+            if (entry.isIntersecting || entry.intersectionRatio > 0) {
+              hydrate();
+            }
+          }
+        }, observerOptions)
+      : null;
+
+    if (io && childRef.current.childElementCount) {
+      // As root node does not have any box model, it cannot intersect.
+      const el = childRef.current.children[0];
+      io.observe(el);
+
+      cleanupFns.push(() => {
+        io.unobserve(el);
+      });
+
+      return cleanup;
+    } else {
+      hydrate();
+    }
+  }, [hydrated, hydrate, childRef, observerOptions]);
+
+  if (hydrated) {
+    return (
+      <div ref={childRef} style={defaultStyle} children={children} {...rest} />
+    );
+  } else {
+    return (
+      <div
+        ref={childRef}
+        style={defaultStyle}
+        suppressHydrationWarning
+        {...rest}
+        dangerouslySetInnerHTML={{ __html: "" }}
+      />
+    );
+  }
+}
+
+export { HydrateWhenVisible };


### PR DESCRIPTION
Splits the component into smaller component for each hydration strategy.
closes #14 

### Notes on hydration when visible
To support `IntersectionObserver` customizations, an `IntersectionObserver` instance is created for each ~~component~~ unique set of `IntersectionObserver` options.
~~As an alternative to this, the component can accept a custom `IntersectionObserver` instance [like this](https://github.com/hadeeb/react-lazy-hydration/commit/92ba688f06a0a3c149803d7bb8efa38b8a530486). It could be beneficial if there is a list of components to be hydrated in a same way or the user needs more control on hydration.~~