### PR TITLE
feat: allow unwrapped items for lazy-hydration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -130,7 +130,7 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
 
   if (hydrated) {
     if (noWrapper) {
-      return <>{children}</>;
+      return children;
     }
     return (
       <div ref={childRef} style={{ display: "contents" }} {...rest}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ export type LazyProps = {
   ssrOnly?: boolean;
   whenIdle?: boolean;
   whenVisible?: boolean;
+  noWrapper?: boolean;
   on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap;
 };
 
@@ -43,7 +44,15 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
   // Always render on server
   const [hydrated, setHydrated] = React.useState(!isBrowser);
 
-  const { ssrOnly, whenIdle, whenVisible, on = [], children, ...rest } = props;
+  const {
+    noWrapper,
+    ssrOnly,
+    whenIdle,
+    whenVisible,
+    on = [],
+    children,
+    ...rest
+  } = props;
 
   if (isDev && !ssrOnly && !whenIdle && !whenVisible && !on.length) {
     console.error(
@@ -120,6 +129,9 @@ const LazyHydrate: React.FunctionComponent<Props> = function(props) {
   }, [hydrated, on, ssrOnly, whenIdle, whenVisible]);
 
   if (hydrated) {
+    if (noWrapper) {
+      return <>{children}</>;
+    }
     return (
       <div ref={childRef} style={{ display: "contents" }} {...rest}>
         {children}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ export type LazyProps = {
   noWrapper?: boolean;
   instantHydrate?: boolean;
   didHydrate?: VoidFunction;
-  promise?: any;
+  promise?: Promise<any>;
   on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap;
 };
 


### PR DESCRIPTION
When hydrating during idle time, we don't need a wrapper div as far as I can tell. 

Id like to have the ability to lazy-hydrate unwrapped components as this can cause style problems across my site due to the wrapping div element. 

New props added. 

`promise` is useful for future plans. Im going to use a custom TTI algorithm which will let me hydrate on the promise resolve
`instantHydrate` is useful for unit tests, which render as <div/>. currently i have to replace it with react.fragment, but i cannot do that since I'm trying to use your div as the wrapper div. The problem is that i cannot easily replace lazyhydrate when i still need it div. noWrapper would work out in some cases, but this is a nice way to pass `process.env.NODE_ENV === "test"`
`didHydrate` as others have requested - it would be very nice to have a hydration callback. This would let me set some new attributes like content-visible. I'd be able to use `content-visibility:auto` and when hydrated, add a class that prevents the page from collapsing already hydrated dom nodes.  This is very useful for rendering and paint performance. I can have parents animate with pointer-events none. This rasterizes the markup and does not cause reflow during transitions. 

