### PR TITLE
fix: Increase rootMarin on IO

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,7 +30,7 @@ const io =
           });
         },
         {
-          rootMargin: "150px"
+          rootMargin: "250px"
         }
       )
     : null;


### PR DESCRIPTION
If a user is scrolling at a faster rate, and there are animations, they will jank as the hydration time forces animations to stutter or skip the initial animation stage. 

One reason i use whenIdle is that the intersection observer is too short which reduces the user experience.