### PR TITLE
feat: allow for dynamic tag other than div

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ function App() {
       <LazyHydrate ssrOnly>
         {...}
       </LazyHydrate>
+      {/* Use Custom Wrapper Tag  */}
+      <LazyHydrate tag={"span"}>
+        {...}
+      </LazyHydrate>
       {/* Requires IntersectionObserver. Polyfill not included. */}
       <LazyHydrate whenVisible>
         {...}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ export type LazyProps = {
   promise?: Promise<any>;
   on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap;
   children: React.ReactElement;
+  as: (keyof JSX.IntrinsicElements)[]
 };
 
 type Props = Omit<React.HTMLProps<HTMLElement>, "dangerouslySetInnerHTML"> &
@@ -42,6 +43,7 @@ function LazyHydrate(props: Props) {
     on = [],
     children,
     didHydrate, // callback for hydration
+    as = 'div',
     ...rest
   } = props;
 
@@ -157,12 +159,13 @@ function LazyHydrate(props: Props) {
     whenVisible,
     didHydrate,
     promise,
-    noWrapper
+    noWrapper,
+    as
   ]);
 
   const WrapperElement = ((typeof noWrapper === "string"
     ? noWrapper
-    : "div") as unknown) as React.FC<React.HTMLProps<HTMLElement>>;
+    : as) as unknown) as React.FC<React.HTMLProps<HTMLElement>>;
 
   if (hydrated) {
     if (noWrapper) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -159,8 +159,7 @@ function LazyHydrate(props: Props) {
     whenVisible,
     didHydrate,
     promise,
-    noWrapper,
-    as
+    noWrapper
   ]);
 
   const WrapperElement = ((typeof noWrapper === "string"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ export type LazyProps = {
   promise?: Promise<any>;
   on?: (keyof HTMLElementEventMap)[] | keyof HTMLElementEventMap;
   children: React.ReactElement;
-  as: (keyof JSX.IntrinsicElements)[]
+  as?: keyof JSX.IntrinsicElements;
 };
 
 type Props = Omit<React.HTMLProps<HTMLElement>, "dangerouslySetInnerHTML"> &


### PR DESCRIPTION
This would allow for use inside SVGs that are JSX where something like `<g>` or `<path>` could be SSR only while still allowing the parent `<SVG>` tags to receive new props like viewbox, height, classes 