### PR TITLE
fix: avoid function call on null

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ function LazyHydrate(props: Props) {
 
   useIsomorphicLayoutEffect(() => {
     // No SSR Content
-    if (!childRef.current.hasChildNodes()) {
+    if (!childRef.current?.hasChildNodes()) {
       hydrate();
     }
   }, []);


### PR DESCRIPTION
I've noticed recently on our sentry logs, that we have the following error : 
![image](https://github.com/hadeeb/react-lazy-hydration/assets/47872542/ef82e7a1-3088-446d-a1a8-b24b1b2c66b7)

I had a look and I see that the ref is initialized with null, so I decided to propose this slight change, to avoid the error.

